### PR TITLE
add dynamic dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ $RECYCLE.BIN/
 .terraform.lock.hcl
 schema-*.json
 *_variables.tf.json
+
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Massdriver, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cloud-run-api/massdriver.yaml
+++ b/cloud-run-api/massdriver.yaml
@@ -24,6 +24,11 @@ dependencies:
   gcp_authentication:
     type: massdriver/gcp-service-account
     required: true
+<md range $key, $art:= .Dependencies md>
+  <md $key md>:
+    type: <md $art md>
+    required: true
+<md end md>
 
 ui:schema:
   ui:order:

--- a/kubernetes-cronjob/massdriver.yaml
+++ b/kubernetes-cronjob/massdriver.yaml
@@ -69,6 +69,11 @@ dependencies:
     type: massdriver/gcp-service-account
     required: true
 <md end md>
+<md range $key, $art:= .Dependencies md>
+  <md $key md>:
+    type: <md $art md>
+    required: true
+<md end md>
 
 
 ui:

--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -81,6 +81,11 @@ dependencies:
     type: massdriver/gcp-service-account
     required: true
 <md end md>
+<md range $key, $art:= .Dependencies md>
+  <md $key md>:
+    type: <md $art md>
+    required: true
+<md end md>
 
 
 ui:

--- a/kubernetes-job/massdriver.yaml
+++ b/kubernetes-job/massdriver.yaml
@@ -69,6 +69,11 @@ dependencies:
     type: massdriver/gcp-service-account
     required: true
 <md end md>
+<md range $key, $art:= .Dependencies md>
+  <md $key md>:
+    type: <md $art md>
+    required: true
+<md end md>
 
 ui:
   ui:order:


### PR DESCRIPTION
FYI this will break `mass app new` for CLIs until https://github.com/massdriver-cloud/massdriver-cli/pull/81 is merged and released. We've decided that's OK because no one is using this part of the CLI yet.