### PR TITLE
Removing oneOf required

### DIFF
--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -85,7 +85,7 @@ params:
           default: false
       dependencies:
         autoscalingEnabled:
-          oneOf: 
+          oneOf:
           - properties:
               autoscalingEnabled:
                 const: false
@@ -132,7 +132,7 @@ params:
           type: boolean
       dependencies:
         enabled:
-          oneOf: 
+          oneOf:
           - properties:
               enabled:
                 const: false
@@ -157,7 +157,7 @@ params:
             required:
             - host
             - path
-          
+
 
 connections:
   required:
@@ -165,10 +165,6 @@ connections:
   <md- range $key, $art:= .Connections md>
     - <md $key md>
   <md- end md>
-  oneOf:
-    - required: ["aws_authentication"]
-    - required: ["gcp_authentication"]
-    - required: ["azure_authentication"]
   properties:
     kubernetes_cluster:
       $ref: massdriver/kubernetes-cluster

--- a/kubernetes-deployment/src/chart/values.yaml
+++ b/kubernetes-deployment/src/chart/values.yaml
@@ -1,5 +1,3 @@
-# TODO: generate a JSON Schema for this, set as params in md yaml, pull fields and add desc.
-# TODO: get a simple nginx app working with this.
 image:
   repository:
   tag:


### PR DESCRIPTION
This doesn't actually work, it completely fails.

Removing this. It will cause the bundle to fail if a cloud account isn't attached, so not great, but better than it failing altogether.