### PR TITLE
Hotfix DNS string error

### DIFF
--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -127,7 +127,7 @@ params:
                   type: string
                 subdomain:
                   title: Subdomain
-                  description: "DNS zone subdomain. Examples: www.yourdomain.com, app.yourdomain.net"
+                  description: "Subdomain for DNS zone. Examples: 'www', 'api', 'app'"
                   type: string
                   pattern: ^[-a-zA-Z0-9*._-]{1,63}$
                   message:

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -110,8 +110,6 @@ params:
       title: DNS
       description: DNS configuration
       type: object
-      required:
-        - enable_dns
       properties:
         enable_dns:
           title: Enable DNS


### PR DESCRIPTION
Getting this error when trying to deploy the app in the UI:
```

exception
exception.type:
"*errors.errorString"
exception.message:
"Invalid value for module argument Details: The given value is not suitable for child module variable "dns" defined at .terraform/modules/application_app_service/massdriver-application-azure-app-service/_variables.tf:8,1-15: attributes "enable_dns", "subdomain", and "zone_name" are required."
```