### PR TITLE
Minor hotfix DNS UI order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ schema-*.json
 *_variables.tf.json
 
 .vscode/
+
+# Infracost
+*.infracost

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -173,7 +173,7 @@ ui:
     ui:order:
       - enable_dns
       - zone_name
-      - sub_domain
+      - subdomain
     zone_name:
       ui:field: dnsZonesDropdown
       cloud: azure


### PR DESCRIPTION
Fixes error:
```
Invalid dns object field configuration:uiSchema order list does not contain property 'subdomain'.

{"description":"DNS configuration","properties":{"enable_dns":{"description":"Enable DNS configuration for the application.","title":"Enable DNS","type":"boolean"},"subdomain":{"description":"DNS zone subdomain. Examples: www.yourdomain.com, app.yourdomain.net","message":{"pattern":"Must be a valid subdomain. Must contain only letters, numbers, dashes, underscores, periods, and asterisks."},"pattern":"^[-a-zA-Z0-9*._-]{1,63}$","title":"Subdomain","type":"string"},"zone_name":{"description":"Azure DNS zone name","title":"DNS Zone name","type":"string"}},"required":["enable_dns","zone_name","subdomain"],"title":"DNS","type":"object"}
```