### PR TITLE
Fix for CIDR requirement

### DIFF
--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -212,6 +212,7 @@ params:
                 type: string
                 description: Specify a /24 CIDR range within your vnet to create subnet for the database. The subnet CIDR cannot be changed after creation.
                 $md.immutable: true
+                default: ""
                 pattern: ^(?:10\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)(?:\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){2}\/24$
                 message:
                   pattern: "Must be a /24 range from within the VNet CIDR"


### PR DESCRIPTION
CIDR field is required in terraform-modules/variables.tf.  Since it's nested in an object, I'm not sure how to set the default to `null`. When I set up my `params` file, I had `cidr: ""` set and it deployed without issues. I think that is all that is needed here to get the schema to cooperate.