### PR TITLE
Removing add'l envs

### DIFF
--- a/kubernetes-cronjob/massdriver.yaml
+++ b/kubernetes-cronjob/massdriver.yaml
@@ -56,20 +56,6 @@ params:
       type: array
       items:
         type: string
-    additionalEnvs:
-      title: Environment Variables
-      description: "List of environment variables to set in the application runtime. Note: Environment variables from connections should be programmatically set in the application configuration file. See https://docs.massdriver.cloud/applications/getting-started#environment-variable-examples"
-      type: array
-      default: []
-      items:
-        type: object
-        properties:
-          name:
-            title: Name
-            type: string
-          value:
-            title: Value
-            type: string
     resourceRequests:
       type: object
       title: Resources
@@ -167,7 +153,6 @@ ui:
     - image
     - command
     - args
-    - additionalEnvs
     - resourceRequests
     - job
     - "*"
@@ -182,8 +167,3 @@ ui:
     memory:
       ui:field: conversionFieldData
       unit: Bytes
-  additionalEnvs:
-    items:
-      ui:order:
-        - name
-        - value

--- a/kubernetes-cronjob/src/main.tf
+++ b/kubernetes-cronjob/src/main.tf
@@ -5,5 +5,5 @@ module "helm" {
   namespace          = var.namespace
   chart              = "${path.module}/chart"
   kubernetes_cluster = var.kubernetes_cluster
-  additional_envs    = var.additionalEnvs
+  additional_envs    = []
 }

--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -57,20 +57,6 @@ params:
       type: array
       items:
         type: string
-    additionalEnvs:
-      title: Environment Variables
-      description: "List of environment variables to set in the application runtime. Note: Environment variables from connections should be programmatically set in the application configuration file. See https://docs.massdriver.cloud/applications/getting-started#environment-variable-examples"
-      type: array
-      default: []
-      items:
-        type: object
-        properties:
-          name:
-            title: Name
-            type: string
-          value:
-            title: Value
-            type: string
     resourceRequests:
       title: Resources
       type: object
@@ -213,7 +199,6 @@ ui:
     - image
     - command
     - args
-    - additionalEnvs
     - resourceRequests
     - replicas
     - port
@@ -223,10 +208,6 @@ ui:
     memory:
       ui:field: conversionFieldData
       unit: Bytes
-  additionalEnvs:
-    ui:order:
-      - name
-      - value
   replicas:
     ui:order:
       - autoscalingEnabled

--- a/kubernetes-deployment/src/main.tf
+++ b/kubernetes-deployment/src/main.tf
@@ -4,5 +4,5 @@ module "helm" {
   namespace          = var.namespace
   chart              = "${path.module}/chart"
   kubernetes_cluster = var.kubernetes_cluster
-  additional_envs    = var.additionalEnvs
+  additional_envs    = []
 }

--- a/kubernetes-job/massdriver.yaml
+++ b/kubernetes-job/massdriver.yaml
@@ -56,20 +56,6 @@ params:
       type: array
       items:
         type: string
-    additionalEnvs:
-      title: Environment Variables
-      description: "List of environment variables to set in the application runtime. Note: Environment variables from connections should be programmatically set in the application configuration file. See https://docs.massdriver.cloud/applications/getting-started#environment-variable-examples"
-      type: array
-      default: []
-      items:
-        type: object
-        properties:
-          name:
-            title: Name
-            type: string
-          value:
-            title: Value
-            type: string
     resourceRequests:
       type: object
       title: Resources
@@ -147,7 +133,6 @@ ui:
     - image
     - command
     - args
-    - additionalEnvs
     - resourceRequests
     - job
     - "*"
@@ -160,8 +145,3 @@ ui:
     memory:
       ui:field: conversionFieldData
       unit: Bytes
-  additionalEnvs:
-    items:
-      ui:order:
-        - name
-        - value

--- a/kubernetes-job/src/main.tf
+++ b/kubernetes-job/src/main.tf
@@ -5,5 +5,5 @@ module "helm" {
   namespace          = var.namespace
   chart              = "${path.module}/chart"
   kubernetes_cluster = var.kubernetes_cluster
-  additional_envs    = var.additionalEnvs
+  additional_envs    = []
 }


### PR DESCRIPTION
The idea of our params system _is_ environment variables.

This breaks builds when someone takes this out of the params and uses our jq/ENV functionality.