### PR TITLE
Update application templates so the env block is valid

### DIFF
--- a/aws-ecs-service/massdriver.yaml
+++ b/aws-ecs-service/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.configuration.log_level
+    # LOG_LEVEL: .params.configuration.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.log_level
+    # LOG_LEVEL: .params.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/azure-function-app/massdriver.yaml
+++ b/azure-function-app/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.log_level
+    # LOG_LEVEL: .params.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/gcp-cloud-function/massdriver.yaml
+++ b/gcp-cloud-function/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.log_level
+    # LOG_LEVEL: .params.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/kubernetes-cronjob/massdriver.yaml
+++ b/kubernetes-cronjob/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.configuration.log_level
+    # LOG_LEVEL: .params.configuration.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.configuration.log_level
+    # LOG_LEVEL: .params.configuration.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks

--- a/kubernetes-job/massdriver.yaml
+++ b/kubernetes-job/massdriver.yaml
@@ -6,9 +6,9 @@ access: private
 type: application
 
 app:
-  envs:
+  envs: {}
     # Use jq expressions to build environment variables from input params or connections
-    LOG_LEVEL: .params.configuration.log_level
+    # LOG_LEVEL: .params.configuration.log_level
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks


### PR DESCRIPTION
Right now a lot of the application templates have an example env that would produce an error. The linter identifies the error and prevents publishing. This fixes it so all application templates are valid the moment they are generated.