### PR TITLE
Numerous QoL updates

### DIFF
--- a/aws-ecs-service/massdriver.yaml
+++ b/aws-ecs-service/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   required:

--- a/aws-lambda/massdriver.yaml
+++ b/aws-lambda/massdriver.yaml
@@ -12,6 +12,11 @@ app:
   # IAM permissions can be assigned to this workload using jq to pull iam from connections
   policies: []
     # - .connections.k8s_auth.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   required:

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 MonitorAlarmMetric: &monitor_alarm_metric
   required:

--- a/azure-function-app/massdriver.yaml
+++ b/azure-function-app/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 MonitorAlarmMetric: &monitor_alarm_metric
   required:

--- a/gcp-cloud-function/massdriver.yaml
+++ b/gcp-cloud-function/massdriver.yaml
@@ -12,6 +12,11 @@ app:
     # MONGO_DSN: .connections.mongo_authentication.data.authentication.username + ":" + .connections.mongo_authentication.data.authentication.password + "@" + .connections.mongo_authentication.data.authentication.hostname + ":" + (.connections.mongo_authentication.data.authentication.port|tostring)
   policies: []
     # Use jq expressions to select policies from artifact security blocks
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   examples: []

--- a/gcp-cloud-run/massdriver.yaml
+++ b/gcp-cloud-run/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   examples: []

--- a/gcp-vm/massdriver.yaml
+++ b/gcp-vm/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   examples:

--- a/kubernetes-cronjob/massdriver.yaml
+++ b/kubernetes-cronjob/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   required:

--- a/kubernetes-cronjob/src/chart/Chart.yaml
+++ b/kubernetes-cronjob/src/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: {{ name }}
-description: A Helm chart for Kubernetes
+name: massdriver-kubernetes-cronjob
+description: A CronJob Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   required:
@@ -192,6 +197,24 @@ connections:
     {{conn.name}}:
       $ref: {{conn.artifact_definition}}
   {% endfor %}
+
+
+#########
+### Uncomment below to enable producing artifacts for your web service.
+### You only need to uncomment the following if you intend to connect your internal services in Massdriver.
+### You will also need to uncomment the contents of `src/_artifacts.tf`.
+#########
+#
+# artifacts:
+#   required:
+#     - public
+#     - internal
+#   properties:
+#     public:
+#       $ref: massdriver/api
+#     internal:
+#       $ref: massdriver/api
+
 
 ui:
   ui:order:

--- a/kubernetes-deployment/src/_artifacts.tf
+++ b/kubernetes-deployment/src/_artifacts.tf
@@ -15,7 +15,7 @@
 #     etc = local.artifact_data_etc
 #     api = {
 #       # The publicly accessible ingress hostname and path
-#       hostname = "${var.ingress.host}${var.ingress.path}"
+#       hostname = var.ingress.enabled ? "${var.ingress.host}${var.ingress.path}" : ""
 #       # By default this all traffic is redirected to HTTPS on port 443
 #       port = 443
 #       protocol = "https"

--- a/kubernetes-deployment/src/_artifacts.tf
+++ b/kubernetes-deployment/src/_artifacts.tf
@@ -1,0 +1,63 @@
+########
+## Uncomment below to enable producing artifacts for your web service.
+## You only need to uncomment the following if you intend to connect your internal services in Massdriver.
+## You will also need to uncomment the corresponding artifacts in `massdriver.yaml`.
+########
+
+# locals {
+#   # etc can contain any custom information you need to pass to downstream services.
+#   # These values are _not_ type checked by Massdriver.
+#   artifact_data_etc = {
+#     anything_you_want = "true"
+#   }
+
+#   public_artifact_data = {
+#     etc = local.artifact_data_etc
+#     api = {
+#       # The publicly accessible ingress hostname and path
+#       hostname = "${var.ingress.host}${var.ingress.path}"
+#       # By default this all traffic is redirected to HTTPS on port 443
+#       port = 443
+#       protocol = "https"
+#     }
+#   }
+
+#   internal_artifact_data = {
+#     etc = local.artifact_data_etc
+#     api = {
+#       # The internal kubernetes service discovery hostname
+#       hostname = "${var.md_metadata.name_prefix}.${var.namespace}.svc.cluster.local"
+#       # By default, the chart exposes the same container port at the service
+#       port = var.port
+#       # Internal cluster communication doesn't have TLS termination since it doesn't go through the ingress controller
+#       protocol = "http"
+#     }
+#   }
+
+#   artifact_specs = {
+#     # An API version is required, you can set to 0.0.0 or "n/a" if you don't version your API.
+#     api = {
+#       version = "0.0.1"
+#     }
+#   }
+# }
+
+# resource "massdriver_artifact" "public" {
+#   field                = "public"
+#   provider_resource_id = "${var.md_metadata.name_prefix}-public-api"
+#   name                 = "Public API endpoint for ${var.md_metadata.name_prefix}"
+#   artifact             = jsonencode({
+#     data = local.public_artifact_data
+#     specs = local.artifact_specs
+#   })
+# }
+
+# resource "massdriver_artifact" "internal" {
+#   field                = "internal"
+#   provider_resource_id = "${var.md_metadata.name_prefix}-internal-api"
+#   name                 = "Kubernetes internal API endpoint for ${var.md_metadata.name_prefix}"
+#   artifact             = jsonencode({
+#     data = local.internal_artifact_data
+#     specs = local.artifact_specs
+#   })
+# }

--- a/kubernetes-deployment/src/chart/Chart.yaml
+++ b/kubernetes-deployment/src/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: {{ name }}
+name: massdriver-kubernetes-deployment
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/kubernetes-job/massdriver.yaml
+++ b/kubernetes-job/massdriver.yaml
@@ -13,6 +13,11 @@ app:
   policies: []
     # Use jq expressions to select policies from artifact security blocks
     # - .connections.sqs.data.security.iam.subscribe
+  secrets: {}
+    # ENV_NAME:
+    #   required: # true or false - whether massdriver should enforce this value being set
+    #   title: # Set the title
+    #   description: # Set a description
 
 params:
   required:

--- a/kubernetes-job/src/chart/Chart.yaml
+++ b/kubernetes-job/src/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: {{ name }}
+name: massdriver-kubernetes-job
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
* Added a commented-out secret block to all application templates
* Change the chart name of helm charts to no longer be templated since the liquid change removed that capability
* Added a commented out artifact block that will work by default for kubernetes deployment