### PR TITLE
Add appropriate whitespace between fences

### DIFF
--- a/aws-ecs-service/massdriver.yaml
+++ b/aws-ecs-service/massdriver.yaml
@@ -259,7 +259,7 @@ connections:
     - aws_authentication
     - ecs_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     aws_authentication:
@@ -267,8 +267,8 @@ connections:
     ecs_cluster:
       $ref: massdriver/aws-ecs-cluster
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 

--- a/aws-lambda/massdriver.yaml
+++ b/aws-lambda/massdriver.yaml
@@ -99,14 +99,14 @@ connections:
   required:
     - aws_authentication
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     aws_authentication:
       $ref: massdriver/aws-iam-role
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -280,7 +280,7 @@ connections:
     - azure_service_principal
     - azure_virtual_network
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     azure_service_principal:
@@ -288,8 +288,8 @@ connections:
     azure_virtual_network:
       $ref: massdriver/azure-virtual-network
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 

--- a/azure-function-app/massdriver.yaml
+++ b/azure-function-app/massdriver.yaml
@@ -308,7 +308,7 @@ connections:
     - azure_service_principal
     - azure_virtual_network
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     azure_service_principal:
@@ -316,8 +316,8 @@ connections:
     azure_virtual_network:
       $ref: massdriver/azure-virtual-network
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 artifacts:

--- a/gcp-cloud-function/massdriver.yaml
+++ b/gcp-cloud-function/massdriver.yaml
@@ -69,7 +69,7 @@ connections:
     - gcp_authentication
     - gcp_subnetwork
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     gcp_authentication:
@@ -77,8 +77,8 @@ connections:
     gcp_subnetwork:
       $ref: massdriver/gcp-subnetwork
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/gcp-cloud-run/massdriver.yaml
+++ b/gcp-cloud-run/massdriver.yaml
@@ -104,7 +104,7 @@ connections:
     - gcp_authentication
     - gcp_subnetwork
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     gcp_authentication:
@@ -112,8 +112,8 @@ connections:
     gcp_subnetwork:
       $ref: massdriver/gcp-subnetwork
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/gcp-vm/massdriver.yaml
+++ b/gcp-vm/massdriver.yaml
@@ -120,7 +120,7 @@ connections:
     - gcp_authentication
     - subnetwork
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     gcp_authentication:
@@ -128,8 +128,8 @@ connections:
     subnetwork:
       $ref: massdriver/gcp-subnetwork
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/kubernetes-cronjob/massdriver.yaml
+++ b/kubernetes-cronjob/massdriver.yaml
@@ -130,7 +130,7 @@ connections:
   required:
     - kubernetes_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     kubernetes_cluster:
@@ -142,8 +142,8 @@ connections:
     azure_authentication:
       $ref: massdriver/azure-service-principal
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/kubernetes-deployment/massdriver.yaml
+++ b/kubernetes-deployment/massdriver.yaml
@@ -182,7 +182,7 @@ connections:
   required:
     - kubernetes_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     kubernetes_cluster:
@@ -194,8 +194,8 @@ connections:
     azure_authentication:
       $ref: massdriver/azure-service-principal
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 

--- a/kubernetes-job/massdriver.yaml
+++ b/kubernetes-job/massdriver.yaml
@@ -110,7 +110,7 @@ connections:
   required:
     - kubernetes_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     kubernetes_cluster:
@@ -122,8 +122,8 @@ connections:
     azure_authentication:
       $ref: massdriver/azure-service-principal
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/phoenix-kubernetes/massdriver.yaml
+++ b/phoenix-kubernetes/massdriver.yaml
@@ -212,7 +212,7 @@ connections:
   required:
     - kubernetes_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     kubernetes_cluster:
@@ -224,8 +224,8 @@ connections:
     azure_authentication:
       $ref: massdriver/azure-service-principal
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 ui:

--- a/rails-kubernetes/massdriver.yaml
+++ b/rails-kubernetes/massdriver.yaml
@@ -214,7 +214,7 @@ connections:
   required:
     - kubernetes_cluster
   {%- for conn in connections %}
-    - {{conn.name-}}
+    - {{ conn.name -}}
   {% endfor %}
   properties:
     kubernetes_cluster:
@@ -226,8 +226,8 @@ connections:
     azure_authentication:
       $ref: massdriver/azure-service-principal
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 
 #########

--- a/terraform-module/massdriver.yaml
+++ b/terraform-module/massdriver.yaml
@@ -34,12 +34,12 @@ connections:
 {%- if connections.size > 0 %}
   required:
   {%- for conn in connections %}
-  - {{conn.name-}}
+  - {{ conn.name -}}
   {% endfor %}
   properties:
   {%- for conn in connections %}
-    {{conn.name}}:
-      $ref: {{conn.artifact_definition-}}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
   {% endfor %}
 {% else %}
   properties: {}


### PR DESCRIPTION
Otherwise certain Liquid implementations such as Elixir's will parse something like
``` {{product-}}```

as `product-` instead of `product and delete whitespace after tag`.