### PR TITLE
Better examples?

### DIFF
--- a/phoenix-kubernetes/examples/.dockerignore
+++ b/phoenix-kubernetes/examples/.dockerignore
@@ -1,0 +1,45 @@
+# This file excludes paths from the Docker build context.
+#
+# By default, Docker's build context includes all files (and folders) in the
+# current directory. Even if a file isn't copied into the container it is still sent to
+# the Docker daemon.
+#
+# There are multiple reasons to exclude files from the build context:
+#
+# 1. Prevent nested folders from being copied into the container (ex: exclude
+#    /assets/node_modules when copying /assets)
+# 2. Reduce the size of the build context and improve build time (ex. /build, /deps, /doc)
+# 3. Avoid sending files containing sensitive information
+#
+# More information on using .dockerignore is available here:
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+.dockerignore
+
+# Ignore git, but keep git HEAD and refs to access current commit hash if needed:
+#
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# d0b8727759e1e0e7aa3d41707d12376e373d5ecc
+.git
+!.git/HEAD
+!.git/refs
+
+# Common development/test artifacts
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+
+# Mix artifacts
+/_build/
+/deps/
+*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Static artifacts - These should be fetched and built inside the Docker image
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/phoenix-kubernetes/examples/Dockerfile
+++ b/phoenix-kubernetes/examples/Dockerfile
@@ -1,0 +1,92 @@
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian instead of
+# Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
+# https://hub.docker.com/_/ubuntu?tab=tags
+#
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20230612-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: hexpm/elixir:1.14.5-erlang-24.3.4.13-debian-bullseye-20230612-slim
+#
+ARG ELIXIR_VERSION=1.14.5
+ARG OTP_VERSION=24.3.4.13
+ARG DEBIAN_VERSION=bullseye-20230612-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} as builder
+
+# install build dependencies
+RUN apt-get update -y && apt-get install -y build-essential git \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+COPY priv priv
+
+COPY lib lib
+
+COPY assets assets
+
+# compile assets
+RUN mix assets.deploy
+
+# Compile the release
+RUN mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# set runner ENV
+ENV MIX_ENV="prod"
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/massdriver ./
+
+USER nobody
+
+CMD ["/app/bin/server"]

--- a/phoenix-kubernetes/install.sh
+++ b/phoenix-kubernetes/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+WORKFLOW_DIRECTORY=./.github/workflows
+WORKFLOW_NAME=md_bundle_publish.yaml
+
+DOCKERFILE_DIRECTORY=./examples
+
+echo -n "Installing bundle publish workflow to $WORKFLOW_DIRECTORY/$WORKFLOW_NAME..."
+mkdir --parents $WORKFLOW_DIRECTORY
+wget -O $WORKFLOW_DIRECTORY/$WORKFLOW_NAME -q https://raw.githubusercontent.com/massdriver-cloud/actions/main/example_workflows/$WORKFLOW_NAME
+echo " done!"
+echo 
+echo "A GitHub workflow has been added at $WORKFLOW_DIRECTORY/$WORKFLOW_NAME".
+echo "It publishes any updates to the bundle to Massdriver on push to main."
+echo "You will need to set two secrets for the repository in GitHub:"
+echo -e '\033[1mMASSDRIVER_API_KEY\033[0m and \033[1mMASSDRIVER_ORG_ID\033[0m.'
+echo "The key/service account can be created at https://app.massdriver.cloud/organization/api-keys."
+echo "The Organization ID can be copied from the same page."
+echo
+
+if [[ -f $DOCKERFILE_DIRECTORY/Dockerfile ]]; then
+    echo "This bundle also contains a Dockerfile in the $DOCKERFILE_DIRECTORY directory."
+    echo "If you do not yet have a Dockerfile for your project, you can use the provided one to get you started."
+fi


### PR DESCRIPTION
* Install the bundle_publish workflow always
* Omitting the app deploy workflow for now - maybe we should tie that to "does an example Dockerfile exist" since we don't at all need it for infra bundles.
* Instead of doing a bunch of shuffling files around, maybe just include the Dockerfile in an "examples" folder and let the user decide if they need it. If they don't, they just delete it, if they do, they'll be happy, if they just want to look at it, it's not in the way.