### PR TITLE
adding force deployment support for ecs

### DIFF
--- a/aws-ecs-service/massdriver.yaml
+++ b/aws-ecs-service/massdriver.yaml
@@ -22,6 +22,7 @@ app:
 params:
   required:
     - image
+    - force_new_deployment
     - runtime
     - autoscaling
     - ports
@@ -43,6 +44,11 @@ params:
           title: Image Tag
           $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/docker-image-tag.json
           default: latest
+    force_new_deployment:
+      title: Force New Deployment
+      description: "Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., myimage:latest)"
+      type: boolean
+      default: false
     runtime:
       title: Runtime Configuration
       type: object
@@ -275,6 +281,7 @@ connections:
 ui:
   ui:order:
     - image
+    - force_new_deployment
     - runtime
     - autoscaling
     - ports

--- a/aws-ecs-service/src/main.tf
+++ b/aws-ecs-service/src/main.tf
@@ -1,10 +1,11 @@
 module "application" {
-  source      = "github.com/massdriver-cloud/terraform-modules//massdriver-application-aws-ecs-service?ref=23a47fa"
-  md_metadata = var.md_metadata
-  ecs_cluster = var.ecs_cluster
-  launch_type = var.runtime.launch_type
-  task_cpu    = var.runtime.cpu
-  task_memory = var.runtime.memory
+  source               = "github.com/massdriver-cloud/terraform-modules//massdriver-application-aws-ecs-service?ref=d7b440e"
+  md_metadata          = var.md_metadata
+  ecs_cluster          = var.ecs_cluster
+  force_new_deployment = var.force_new_deployment
+  launch_type          = var.runtime.launch_type
+  task_cpu             = var.runtime.cpu
+  task_memory          = var.runtime.memory
   logging = {
     driver    = var.monitoring.logging.destination
     retention = lookup(var.monitoring.logging, "retention", null)


### PR DESCRIPTION
We should send a patch out to customers asking for support that may have a rendered template:

```
diff --git a/aws-ecs-service/massdriver.yaml b/aws-ecs-service/massdriver.yaml
index c1dc9fe..db9dd1f 100644
--- a/aws-ecs-service/massdriver.yaml
+++ b/aws-ecs-service/massdriver.yaml
@@ -22,6 +22,7 @@ app:
 params:
   required:
     - image
+    - force_new_deployment
     - runtime
     - autoscaling
     - ports
@@ -43,6 +44,11 @@ params:
           title: Image Tag
           $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/docker-image-tag.json
           default: latest
+    force_new_deployment:
+      title: Force New Deployment
+      description: "Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., myimage:latest)"
+      type: boolean
+      default: false
     runtime:
       title: Runtime Configuration
       type: object
@@ -275,6 +281,7 @@ connections:
 ui:
   ui:order:
     - image
+    - force_new_deployment
     - runtime
     - autoscaling
     - ports
diff --git a/aws-ecs-service/src/main.tf b/aws-ecs-service/src/main.tf
index 835b5cc..d312bc4 100644
--- a/aws-ecs-service/src/main.tf
+++ b/aws-ecs-service/src/main.tf
@@ -1,10 +1,11 @@
 module "application" {
-  source      = "github.com/massdriver-cloud/terraform-modules//massdriver-application-aws-ecs-service?ref=23a47fa"
-  md_metadata = var.md_metadata
-  ecs_cluster = var.ecs_cluster
-  launch_type = var.runtime.launch_type
-  task_cpu    = var.runtime.cpu
-  task_memory = var.runtime.memory
+  source               = "github.com/massdriver-cloud/terraform-modules//massdriver-application-aws-ecs-service?ref=d7b440e"
+  md_metadata          = var.md_metadata
+  ecs_cluster          = var.ecs_cluster
+  force_new_deployment = var.force_new_deployment
+  launch_type          = var.runtime.launch_type
+  task_cpu             = var.runtime.cpu
+  task_memory          = var.runtime.memory
   logging = {
     driver    = var.monitoring.logging.destination
     retention = lookup(var.monitoring.logging, "retention", null)
```