### PR TITLE
Add pod labels in app template

### DIFF
--- a/kubernetes-deployment/src/chart/templates/deployment.yaml
+++ b/kubernetes-deployment/src/chart/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "application.labels" . | nindent 8 }}
+        {{- .Values.pod.labels | toYaml | nindent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes-deployment/src/chart/templates/deployment.yaml
+++ b/kubernetes-deployment/src/chart/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "application.labels" . | nindent 8 }}
-        {{- .Values.pod.labels | toYaml | nindent 8}}
+        {{- .Values.pod.labels | toYaml | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes-deployment/src/chart/values.yaml
+++ b/kubernetes-deployment/src/chart/values.yaml
@@ -34,3 +34,4 @@ commonLabels: {}
 
 pod:
   annotations: {}
+  labels: {}

--- a/kubernetes-deployment/src/main.tf
+++ b/kubernetes-deployment/src/main.tf
@@ -1,6 +1,6 @@
 
 module "helm" {
-  source             = "github.com/massdriver-cloud/terraform-modules//massdriver-application-helm?ref=40bbc7b"
+  source             = "github.com/massdriver-cloud/terraform-modules//massdriver-application-helm?ref=45b7ffa"
   name               = var.md_metadata.name_prefix
   namespace          = var.namespace
   chart              = "${path.module}/chart"


### PR DESCRIPTION
Result of the change:
```
➜  new-k8s-app k describe po dev-test-news-vbnh-69cf48676c-pbxbl
Name:             dev-test-news-vbnh-69cf48676c-pbxbl
Namespace:        default
Priority:         0
Service Account:  dev-test-news-vbnh
Node:             aks-default-27325224-vmss000003/10.21.0.18
Start Time:       Thu, 04 Jan 2024 09:18:59 -0800
Labels:           app.kubernetes.io/chart=massdriver-kubernetes-deployment-0.0.6
                  app.kubernetes.io/deployed-with=massdriver.cloud
                  app.kubernetes.io/name=dev-test-news-vbnh
                  azure.workload.identity/use=true
                  managed-by=massdriver
                  md-manifest=news
                  md-package=dev-test-news-vbnh
                  md-project=dev
                  md-target=test
                  pod-template-hash=69cf48676c
Annotations:      md-deployment-id: aa3e2852-2f8b-46c3-8924-8b65547b7705
```