### PR TITLE
Fixing docker image registry issue

### DIFF
--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -1,6 +1,6 @@
 schema: draft-07
-name: {{ name }}
-description: {{ description }}
+name: test #{{ name }}
+description: test #{{ description }}
 source_url: github.com/YOUR_ORG/{{ name }}
 access: private
 type: application
@@ -178,18 +178,12 @@ params:
       title: Container image configuration
       type: object
       required:
-        - registry
-        - name
+        - repository
         - tag
       properties:
-        registry:
-          title: Image registry
-          description: "Registry of the container image to use for this application. For example: yourregistry.azurecr.io or docker.io"
-          type: string
-          $md.immutable: true
-        name:
-          title: Image name
-          description: "Repository of the container image to use for this application. Include namespace if applicable, for example: namespace/image-name"
+        repository:
+          title: Image repository
+          description: "Repository URI of the container image to use for this application. Include namespace if applicable, for example: yourregistry.azurecr.io/namespace/image"
           type: string
           $md.immutable: true
         tag:
@@ -278,18 +272,18 @@ connections:
   required:
     - azure_service_principal
     - azure_virtual_network
-  {%- for conn in connections %}
-    - {{ conn.name -}}
-  {% endfor %}
+  # {%- for conn in connections %}
+  #   - {{ conn.name -}}
+  # {% endfor %}
   properties:
     azure_service_principal:
       $ref: massdriver/azure-service-principal
     azure_virtual_network:
       $ref: massdriver/azure-virtual-network
-  {%- for conn in connections %}
-    {{ conn.name }}:
-      $ref: {{ conn.artifact_definition -}}
-  {% endfor %}
+  # {%- for conn in connections %}
+  #   {{ conn.name }}:
+  #     $ref: {{ conn.artifact_definition -}}
+  # {% endfor %}
 
 #########
 ### Uncomment below to enable producing artifacts for your web service.
@@ -321,8 +315,7 @@ ui:
       - "*"
   image:
     ui:order:
-      - registry
-      - name
+      - repository
       - tag
       - "*"
   dns:

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -1,6 +1,6 @@
 schema: draft-07
-name: test #{{ name }}
-description: test #{{ description }}
+name: {{ name }}
+description: {{ description }}
 source_url: github.com/YOUR_ORG/{{ name }}
 access: private
 type: application
@@ -272,18 +272,18 @@ connections:
   required:
     - azure_service_principal
     - azure_virtual_network
-  # {%- for conn in connections %}
-  #   - {{ conn.name -}}
-  # {% endfor %}
+  {%- for conn in connections %}
+    - {{ conn.name -}}
+  {% endfor %}
   properties:
     azure_service_principal:
       $ref: massdriver/azure-service-principal
     azure_virtual_network:
       $ref: massdriver/azure-virtual-network
-  # {%- for conn in connections %}
-  #   {{ conn.name }}:
-  #     $ref: {{ conn.artifact_definition -}}
-  # {% endfor %}
+  {%- for conn in connections %}
+    {{ conn.name }}:
+      $ref: {{ conn.artifact_definition -}}
+  {% endfor %}
 
 #########
 ### Uncomment below to enable producing artifacts for your web service.

--- a/azure-app-service/massdriver.yaml
+++ b/azure-app-service/massdriver.yaml
@@ -178,12 +178,18 @@ params:
       title: Container image configuration
       type: object
       required:
-      - name
-      - tag
+        - registry
+        - name
+        - tag
       properties:
+        registry:
+          title: Image registry
+          description: "Registry of the container image to use for this application. For example: yourregistry.azurecr.io or docker.io"
+          type: string
+          $md.immutable: true
         name:
-          title: Image repository
-          description: "Repository of the container image to use for this application. Include namespace if applicable, for example: yourregistry.azurecr.io/namespace/image-name"
+          title: Image name
+          description: "Repository of the container image to use for this application. Include namespace if applicable, for example: namespace/image-name"
           type: string
           $md.immutable: true
         tag:
@@ -315,6 +321,7 @@ ui:
       - "*"
   image:
     ui:order:
+      - registry
       - name
       - tag
       - "*"

--- a/azure-app-service/src/main.tf
+++ b/azure-app-service/src/main.tf
@@ -1,7 +1,3 @@
-locals {
-  docker_registry_url = strcontains(var.image.name, "azurecr.io") ? "https://mcr.microsoft.com" : "https://index.docker.io"
-}
-
 module "application" {
   source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=a1b2019"
   name                = var.md_metadata.name_prefix
@@ -99,7 +95,7 @@ resource "azurerm_linux_web_app" "main" {
     }
 
     application_stack {
-      docker_registry_url = local.docker_registry_url
+      docker_registry_url = "https://${var.image.registry}"
       docker_image_name   = "${var.image.name}:${var.image.tag}"
     }
   }


### PR DESCRIPTION
Had to expose registry as a new var now with the way that Azure is formatting their docker image config:

![image](https://github.com/massdriver-cloud/application-templates/assets/8037512/7d6028c1-b706-45c3-b888-ef587d61e55e)
