### PR TITLE
set tf type to infra

### DIFF
--- a/opentofu-module/massdriver.yaml
+++ b/opentofu-module/massdriver.yaml
@@ -4,7 +4,7 @@ name: "{{ name }}"
 description: "{{ description }}"
 source_url: github.com/YOUR_NAME_HERE/{{ name }}
 access: private
-type: "{{ type }}"
+type: infrastructure
 
 # schema-params.json
 # JSON Schema sans-fields above

--- a/terraform-module/massdriver.yaml
+++ b/terraform-module/massdriver.yaml
@@ -4,7 +4,7 @@ name: "{{ name }}"
 description: "{{ description }}"
 source_url: github.com/YOUR_NAME_HERE/{{ name }}
 access: private
-type: "{{ type }}"
+type: "infrastructure"
 
 # schema-params.json
 # JSON Schema sans-fields above


### PR DESCRIPTION
the `type` field is blank when this runs and its always missing from the massdriver.yaml... hard coding it since it'll always _most likely_ be infra