### PR TITLE
Update the application templates to merge envs and secrets into app envs

### DIFF
--- a/aws-ecs-service/src/main.tf
+++ b/aws-ecs-service/src/main.tf
@@ -61,12 +61,10 @@ resource "aws_ecs_task_definition" "main" {
       memory    = var.runtime.memory
       essential = true
 
-      environment = [for name, value in module.application.envs :
-        {
-          name  = name
-          value = value
-        }
-      ]
+      environment = concat(
+        [for key, val in module.application.envs : { name = key, value = tostring(val) }],
+        [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
+      )
 
       portMappings = [for port in var.ports :
         {

--- a/aws-lambda/src/main.tf
+++ b/aws-lambda/src/main.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "main" {
   timeout       = var.runtime.execution_timeout
 
   environment {
-    variables = module.application.envs
+    variables = merge(module.application.envs, module.application.secrets)
   }
 
   dynamic "tracing_config" {

--- a/azure-app-service/src/main.tf
+++ b/azure-app-service/src/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_linux_web_app" "main" {
   client_certificate_mode    = "Optional"
   tags                       = var.md_metadata.default_tags
 
-  app_settings = merge(module.application.envs, {
+  app_settings = merge(module.application.envs, module.application.secrets, {
     "APPINSIGHTS_INSTRUMENTATIONKEY" = "${azurerm_application_insights.main.instrumentation_key}",
     "APPINSIGHTS_CONNECTION_STRING"  = "${azurerm_application_insights.main.connection_string}",
     # This environment variable enables application insights: (https://github.com/hashicorp/terraform-provider-azurerm/issues/19653#issuecomment-1347802887)

--- a/azure-function-app/src/main.tf
+++ b/azure-function-app/src/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app" "main" {
   virtual_network_subnet_id   = azurerm_subnet.main.id
   tags                        = var.md_metadata.default_tags
 
-  app_settings = merge(module.application.envs, {
+  app_settings = merge(module.application.envs, module.application.secrets, {
     /* Documented workaround for an issue with dockerized functions in the function app:
     https://github.com/Azure/azure-functions-docker/issues/642#issuecomment-1266230863
     https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux&tabs=debian#use-persistent-shared-storage */

--- a/gcp-cloud-run/src/main.tf
+++ b/gcp-cloud-run/src/main.tf
@@ -28,7 +28,7 @@ resource "google_cloud_run_service" "main" {
           container_port = var.container.port
         }
         dynamic "env" {
-          for_each = module.application.envs
+          for_each = merge(module.application.envs, module.application.secrets)
           content {
             name  = env.key
             value = env.value

--- a/kubernetes-cronjob/src/chart/templates/_helpers.tpl
+++ b/kubernetes-cronjob/src/chart/templates/_helpers.tpl
@@ -31,3 +31,13 @@ Selector labels
 {{- define "application.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "application.fullname" . }}
 {{- end }}
+
+{{/*
+Pod labels
+*/}}
+{{- define "application.podLabels" -}}
+{{ include "application.labels" . }}
+{{- with .Values.pod.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/kubernetes-cronjob/src/chart/templates/cronjob.yaml
+++ b/kubernetes-cronjob/src/chart/templates/cronjob.yaml
@@ -15,8 +15,12 @@ spec:
       parallelism: {{ .Values.job.parallelism }}
       template:
         metadata:
+          {{- with .Values.pod.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           labels:
-            {{- include "application.labels" . | nindent 12 }}
+            {{- include "application.podLabels" . | nindent 8 }}
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ include "application.fullname" . }}

--- a/kubernetes-cronjob/src/chart/values.yaml
+++ b/kubernetes-cronjob/src/chart/values.yaml
@@ -22,3 +22,7 @@ job:
   parallelism:
 
 commonLabels: {}
+
+pod:
+  annotations: {}
+  labels: {}

--- a/kubernetes-cronjob/src/helm_values.tf
+++ b/kubernetes-cronjob/src/helm_values.tf
@@ -11,13 +11,5 @@ locals {
       [for key, val in module.application.envs : { name = key, value = tostring(val) }],
       [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
     )
-    ingress = {
-      className = "nginx" // TODO: eventually this should come from the kubernetes artifact
-      annotations = {
-        "cert-manager.io/cluster-issuer" : "letsencrypt-prod"     // TODO: eventually this should come from kubernetes artifact
-        "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true" // TODO: hardcoding this for now, dependent on nginx
-      }
-    }
-    serviceAccount = local.cloud_service_accounts[module.application.cloud]
   }
 }

--- a/kubernetes-cronjob/src/main.tf
+++ b/kubernetes-cronjob/src/main.tf
@@ -23,5 +23,6 @@ resource "helm_release" "application" {
     fileexists("${path.module}/chart/values.yaml") ? file("${path.module}/chart/values.yaml") : "",
     yamlencode(module.application.params),
     yamlencode(module.application.connections),
+    yamlencode(local.helm_values),
   ]
 }

--- a/kubernetes-job/src/chart/templates/_helpers.tpl
+++ b/kubernetes-job/src/chart/templates/_helpers.tpl
@@ -39,3 +39,13 @@ Selector labels
 {{- define "application.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "application.fullname" . }}
 {{- end }}
+
+{{/*
+Pod labels
+*/}}
+{{- define "application.podLabels" -}}
+{{ include "application.labels" . }}
+{{- with .Values.pod.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/kubernetes-job/src/chart/templates/job.yaml
+++ b/kubernetes-job/src/chart/templates/job.yaml
@@ -10,8 +10,12 @@ spec:
   ttlSecondsAfterFinished: 600
   template:
     metadata:
+      {{- with .Values.pod.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        {{- include "application.labels" . | nindent 8 }}
+        {{- include "application.podLabels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "application.fullname" . }}

--- a/kubernetes-job/src/chart/values.yaml
+++ b/kubernetes-job/src/chart/values.yaml
@@ -20,3 +20,7 @@ job:
   parallelism:
 
 commonLabels: {}
+
+pod:
+  annotations: {}
+  labels: {}

--- a/kubernetes-job/src/helm_values.tf
+++ b/kubernetes-job/src/helm_values.tf
@@ -11,13 +11,5 @@ locals {
       [for key, val in module.application.envs : { name = key, value = tostring(val) }],
       [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
     )
-    ingress = {
-      className = "nginx" // TODO: eventually this should come from the kubernetes artifact
-      annotations = {
-        "cert-manager.io/cluster-issuer" : "letsencrypt-prod"     // TODO: eventually this should come from kubernetes artifact
-        "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true" // TODO: hardcoding this for now, dependent on nginx
-      }
-    }
-    serviceAccount = local.cloud_service_accounts[module.application.cloud]
   }
 }

--- a/kubernetes-job/src/main.tf
+++ b/kubernetes-job/src/main.tf
@@ -23,5 +23,6 @@ resource "helm_release" "application" {
     fileexists("${path.module}/chart/values.yaml") ? file("${path.module}/chart/values.yaml") : "",
     yamlencode(module.application.params),
     yamlencode(module.application.connections),
+    yamlencode(local.helm_values),
   ]
 }

--- a/rails-kubernetes/src/helm_values.tf
+++ b/rails-kubernetes/src/helm_values.tf
@@ -22,7 +22,10 @@ locals {
       }
       labels = local.cloud_pod_labels[module.application.cloud]
     }
-    envs = [for key, val in module.application.envs : { name = key, value = tostring(val) }]
+    envs = concat(
+      [for key, val in module.application.envs : { name = key, value = tostring(val) }],
+      [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
+    )
     ingress = {
       className = "nginx" // TODO: eventually this should come from the kubernetes artifact
       annotations = {


### PR DESCRIPTION
Previously we split out envs and secrets to separate outputs in the `massdriver-application` module. This allows users to interact with them separately if needed. However, it means secrets weren't getting injected into the application environment variables.

This updates the application templates so that by default, `envs` and `secrets` will get merged before being submitted to the application as the set of environment variables.