### PR TITLE
Use the new envs_and_secrets output from application module

### DIFF
--- a/aws-ecs-service/src/main.tf
+++ b/aws-ecs-service/src/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "container"
 }
@@ -61,10 +61,7 @@ resource "aws_ecs_task_definition" "main" {
       memory    = var.runtime.memory
       essential = true
 
-      environment = concat(
-        [for key, val in module.application.envs : { name = key, value = tostring(val) }],
-        [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
-      )
+      environment = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
 
       portMappings = [for port in var.ports :
         {

--- a/aws-lambda/src/main.tf
+++ b/aws-lambda/src/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "function"
 }
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "main" {
   timeout       = var.runtime.execution_timeout
 
   environment {
-    variables = merge(module.application.envs, module.application.secrets)
+    variables = module.application.envs_and_secrets
   }
 
   dynamic "tracing_config" {

--- a/azure-app-service/src/main.tf
+++ b/azure-app-service/src/main.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "application" {
-  source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name                = var.md_metadata.name_prefix
   service             = "function"
   resource_group_name = azurerm_resource_group.main.name
@@ -40,7 +40,7 @@ resource "azurerm_linux_web_app" "main" {
   client_certificate_mode    = "Optional"
   tags                       = var.md_metadata.default_tags
 
-  app_settings = merge(module.application.envs, module.application.secrets, {
+  app_settings = merge(module.application.envs_and_secrets, {
     "APPINSIGHTS_INSTRUMENTATIONKEY" = "${azurerm_application_insights.main.instrumentation_key}",
     "APPINSIGHTS_CONNECTION_STRING"  = "${azurerm_application_insights.main.connection_string}",
     # This environment variable enables application insights: (https://github.com/hashicorp/terraform-provider-azurerm/issues/19653#issuecomment-1347802887)

--- a/azure-function-app/src/main.tf
+++ b/azure-function-app/src/main.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 module "application" {
-  source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name                = var.md_metadata.name_prefix
   service             = "function"
   resource_group_name = azurerm_resource_group.main.name

--- a/azure-function-app/src/main.tf
+++ b/azure-function-app/src/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app" "main" {
   virtual_network_subnet_id   = azurerm_subnet.main.id
   tags                        = var.md_metadata.default_tags
 
-  app_settings = merge(module.application.envs, module.application.secrets, {
+  app_settings = merge(module.application.envs_and_secrets, {
     /* Documented workaround for an issue with dockerized functions in the function app:
     https://github.com/Azure/azure-functions-docker/issues/642#issuecomment-1266230863
     https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux&tabs=debian#use-persistent-shared-storage */

--- a/gcp-cloud-run/src/main.tf
+++ b/gcp-cloud-run/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "function"
 }
@@ -28,7 +28,7 @@ resource "google_cloud_run_service" "main" {
           container_port = var.container.port
         }
         dynamic "env" {
-          for_each = merge(module.application.envs, module.application.secrets)
+          for_each = module.application.envs_and_secrets
           content {
             name  = env.key
             value = env.value

--- a/kubernetes-cronjob/src/helm_values.tf
+++ b/kubernetes-cronjob/src/helm_values.tf
@@ -7,9 +7,6 @@ locals {
       }
       labels = local.cloud_pod_labels[module.application.cloud]
     }
-    envs = concat(
-      [for key, val in module.application.envs : { name = key, value = tostring(val) }],
-      [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
-    )
+    envs = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
   }
 }

--- a/kubernetes-cronjob/src/main.tf
+++ b/kubernetes-cronjob/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "kubernetes"
 

--- a/kubernetes-deployment/src/helm_values.tf
+++ b/kubernetes-deployment/src/helm_values.tf
@@ -7,10 +7,7 @@ locals {
       }
       labels = local.cloud_pod_labels[module.application.cloud]
     }
-    envs = concat(
-      [for key, val in module.application.envs : { name = key, value = tostring(val) }],
-      [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
-    )
+    envs = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
     ingress = {
       className = "nginx" // TODO: eventually this should come from the kubernetes artifact
       annotations = {

--- a/kubernetes-deployment/src/main.tf
+++ b/kubernetes-deployment/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "kubernetes"
 

--- a/kubernetes-job/src/helm_values.tf
+++ b/kubernetes-job/src/helm_values.tf
@@ -7,9 +7,6 @@ locals {
       }
       labels = local.cloud_pod_labels[module.application.cloud]
     }
-    envs = concat(
-      [for key, val in module.application.envs : { name = key, value = tostring(val) }],
-      [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
-    )
+    envs = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
   }
 }

--- a/kubernetes-job/src/main.tf
+++ b/kubernetes-job/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "kubernetes"
 

--- a/phoenix-kubernetes/src/helm_values.tf
+++ b/phoenix-kubernetes/src/helm_values.tf
@@ -1,5 +1,12 @@
 locals {
   helm_values = {
+    commonLabels = var.md_metadata.default_tags
+    pod = {
+      annotations = {
+        "md-deployment-id" = lookup(module.application.params.md_metadata.deployment, "id", "")
+      }
+    }
+    envs = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
     # # The default command, args, and migration settings are below. Any
     # # values in values.yaml can be overwritten by adding a parameter to your massdriver.yaml
     # # or by hard coding the value here

--- a/phoenix-kubernetes/src/main.tf
+++ b/phoenix-kubernetes/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "kubernetes"
 

--- a/rails-kubernetes/src/helm_values.tf
+++ b/rails-kubernetes/src/helm_values.tf
@@ -22,10 +22,7 @@ locals {
       }
       labels = local.cloud_pod_labels[module.application.cloud]
     }
-    envs = concat(
-      [for key, val in module.application.envs : { name = key, value = tostring(val) }],
-      [for key, val in module.application.secrets : { name = key, value = tostring(val) }]
-    )
+    envs = [for key, val in module.application.envs_and_secrets : { name = key, value = tostring(val) }]
     ingress = {
       className = "nginx" // TODO: eventually this should come from the kubernetes artifact
       annotations = {

--- a/rails-kubernetes/src/main.tf
+++ b/rails-kubernetes/src/main.tf
@@ -1,5 +1,5 @@
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=48e6b4a"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=1cc739c"
   name    = var.md_metadata.name_prefix
   service = "kubernetes"
 


### PR DESCRIPTION
Instead of combining `module.application.envs` with `module.application.secrets` we can use the new `envs_and_secrets` output which automatically combines them.